### PR TITLE
Check if stream is closed before attempting reconnection

### DIFF
--- a/stream.go
+++ b/stream.go
@@ -105,12 +105,12 @@ func (stream *Stream) stream() {
 	var err error
 
 connect:
+	if stream.state == StreamClosed {
+		return
+	}
 	stream.state = StreamConnecting
 	for backoff := stream.retry; ; backoff *= 2 {
 		stream.Response, err = stream.Client.Do(stream.Request)
-		if stream.state == StreamClosed {
-			return
-		}
 		if err != nil || stream.Response.StatusCode != 200 {
 			if err = stream.Client.CheckReconnect(stream, err); err != nil {
 				return


### PR DESCRIPTION
I believe the check to stop a stream connection if its closed should be earlier. I had a situation today where I have a stream listening in a goroutine and it is closed in another goroutine, but the first goroutine keeps listening.

This patch fixes my issue.
